### PR TITLE
update compileSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
linking error while building after migrating to androidx.  needed compileSdkVersion 28 to build successfully.  advice per https://github.com/flutter/flutter/issues/27226#issuecomment-567018039